### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,17 +12,15 @@ services:
       - "3000:3000"
     depends_on:
       - db
-    command: /bin/sh -c "bundle exec rails db:migrate && rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    command: /bin/sh -c "bundle exec rails db:create db:migrate && rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     tty: true
     stdin_open: true
 
   db:
     image: mysql:5.7.26
+    command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci
     environment:
-      - MYSQL_ROOT_PASSWORD=password
-      - MYSQL_DATABASE=app_development
-      - MYSQL_USER=root
-      - MYSQL_PASSWORD=password
+      MYSQL_ROOT_PASSWORD: password
     ports:
       - "4306:3306"
     volumes:


### PR DESCRIPTION
# WHY
ローカルのdockerのMySQLでlatin1が使われ、仮名文字が保存出来ないのでutf8に変更するため。

# WHAT
MySQLでutf8を指定
不要な環境変数を削除