### PR TITLE
パンくず機能(画面下部)の実装

### DIFF
--- a/app/assets/stylesheets/_breadcrumbs_bottom.scss
+++ b/app/assets/stylesheets/_breadcrumbs_bottom.scss
@@ -1,0 +1,25 @@
+.breadcrumbs-bottom {
+  position: relative;
+  background-color: #f5f5f5;
+  border-top: 1px solid #eee;
+  height: 50px;
+  &__list {
+    margin: 0 210px;
+    padding: 16px 0;
+    font-size: 13px;
+    letter-spacing: 1px;
+    line-height: 1.2;
+    & a {
+      color: rgb(51, 51, 51);
+      text-decoration: none;
+    }
+    & i {
+      color: #888;
+      margin: 0 2px;
+      -webkit-text-stroke: 1.5px #f5f5f5;
+    }
+    & span {
+      font-weight: bold;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,6 +5,7 @@
 @import "./profile";
 @import "./logout";
 @import "./breadcrumbs";
+@import "./breadcrumbs_bottom";
 @import "identification";
 @import "users/sign_index";
 @import "users/sign_up_view";

--- a/app/assets/stylesheets/items/_search.scss
+++ b/app/assets/stylesheets/items/_search.scss
@@ -5,6 +5,7 @@
   .search-container {
     display: flex;
     margin: 0 auto;
+    padding: 0 0 40px;
     width: 1020px;
     &__side {
       width: 280px;
@@ -183,4 +184,20 @@
       }
     }
   }
-  
+
+.top-footer {
+  position: relative;
+  background-color: #f5f5f5;
+  border-top: 1px solid #eee;
+  height: 50px;
+  &__list {
+    margin: 0 210px;
+    padding: 16px 0;
+    letter-spacing: 1px;
+    line-height: 1.2;
+    & span {
+      font-size: 13px;
+      font-weight: bold;
+    }
+  }
+}

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -143,4 +143,7 @@
                     = item.name
                   .search-container__content__items__box__detail__bottom__price
                     = "¥" + number_with_delimiter(item.price)
+.top-footer
+  .top-footer__list
+    %span メルカリ
 = render 'footer'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -122,5 +122,6 @@
       = link_to "ブリスポイントのガウチョパンツ その他の商品", "", class: "itempage__container__box--title"
       %ul.itempage__container__box--content
         
-      
+- breadcrumb :item_show, @item
+= render 'shared/breadcrumbs_bottom'
 = render 'footer'

--- a/app/views/shared/_breadcrumbs_bottom.html.haml
+++ b/app/views/shared/_breadcrumbs_bottom.html.haml
@@ -1,0 +1,2 @@
+.breadcrumbs-bottom
+  = breadcrumbs pretext: "", separator: " #{content_tag(:i, "", class: "fa fa-chevron-right")} ", class: "breadcrumbs-bottom__list"

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -2,6 +2,11 @@ crumb :root do
   link "メルカリ", root_path
 end
 
+crumb :item_show do |item|
+  link "#{item.name}"
+  parent :root
+end
+
 crumb :mypage do
   link "マイページ", user_path
   parent :root

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -8,31 +8,31 @@ crumb :item_show do |item|
 end
 
 crumb :mypage do
-  link "マイページ", user_path
+  link "マイページ", user_path(current_user)
   parent :root
 end
 
 crumb :exhibit_items_now do
-  link "出品した商品 - 出品中", items_list_user_path
+  link "出品した商品 - 出品中"
   parent :mypage
 end
 
 crumb :profile do
-  link "プロフィール", profile_user_path
+  link "プロフィール"
   parent :mypage
 end
 
 crumb :card do
-  link "支払い方法", users_cards_path
+  link "支払い方法"
   parent :mypage
 end
 
 crumb :identification do 
-  link "本人情報の登録", identification_user_path
+  link "本人情報の登録"
   parent :mypage
 end
 
 crumb :logout do
-  link "ログアウト", logout_user_path
+  link "ログアウト"
   parent :mypage
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -110,9 +110,9 @@ ActiveRecord::Schema.define(version: 2019_08_16_114432) do
     t.datetime "updated_at", null: false
     t.string "first_name_kana", null: false
     t.string "last_name_kana", null: false
-    t.string "payjp_cus"
     t.string "provider"
     t.string "uid"
+    t.string "payjp_cus"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# What
パンくず機能を画面下部に実装する。ファイルを新たに作成し、商品詳細ページの下部にパンくず機能を実装する。

# Why
画面下部にホームへのリンクと、商品名を表示させてユーザビリティを向上させる為。