### PR TITLE
ページネーションの修正

### DIFF
--- a/app/assets/stylesheets/category/_show.scss
+++ b/app/assets/stylesheets/category/_show.scss
@@ -90,8 +90,6 @@
       }
       &__pager {
         margin: 40px 0 0;
-        text-align: center;
-
       }
       &__description {
         overflow: hidden;

--- a/app/assets/stylesheets/kaminari/_kaminari.scss
+++ b/app/assets/stylesheets/kaminari/_kaminari.scss
@@ -1,4 +1,5 @@
 .pagination {
+  text-align: center;
   .page {
     font-size: 13px;
     line-height: 42px;
@@ -22,10 +23,9 @@
   }
   & .first,.prev {
     float: left;
-    font-size: 16px;
-    font-weight: bold;
+    font-size: 35px;
     line-height: 42px;
-    display: inline-block;
+    display: block;
     width: 44px;
     height: 44px;
     & a {
@@ -39,10 +39,9 @@
   }
   & .next,.last {
     float: right;
-    font-size: 16px;
-    font-weight: bold;
+    font-size: 35px;
     line-height: 42px;
-    display: inline-block;
+    display: block;
     width: 44px;
     height: 44px;
     & a {

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -14,7 +14,7 @@ class CategoriesController < ApplicationController
   
   def show
     items = category_items(@category)
-    @items = Kaminari.paginate_array(items).page(params[:page]).per(1)
+    @items = Kaminari.paginate_array(items).page(params[:page]).per(125)
   end
   private
   def set_category

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -26,7 +26,12 @@
                   .category-lists-wrapper__container__content__box__list__item__bottom__price
                     = "¥" + number_with_delimiter(item.price)
       .category-lists-wrapper__container__content__pager
-        = paginate @items
+        - if @items.current_page == 1 || @items.current_page == @items.total_pages
+          = paginate @items, window: 4
+        - elsif @items.current_page == 2 || @items.current_page == @items.total_pages - 1
+          = paginate @items, window: 3
+        - else
+          = paginate @items, window: 2
       .category-lists-wrapper__container__content__description
         .category-lists-wrapper__container__content__description__title
           %h3

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -4,5 +4,5 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
-%span.page.gap
-  = t('views.pagination.truncate').html_safe
+-# %span.page.gap
+-#   = t('views.pagination.truncate').html_safe

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -14,5 +14,5 @@
         = page_tag page
       - elsif !page.was_truncated?
         = gap_tag
-    = next_page_tag unless current_page.last?
     = last_page_tag unless current_page.last?
+    = next_page_tag unless current_page.last?

--- a/config/locales/kaminari.yml
+++ b/config/locales/kaminari.yml
@@ -1,17 +1,17 @@
-en:
+ja:
   views:
     pagination:
-      first: "<<"
-      last: ">"
-      previous: "<"
-      next: ">>"
+      first: "&laquo;"
+      last: "&raquo;"
+      previous: "&lsaquo;"
+      next: "&rsaquo;"
       truncate: "&hellip;"
   helpers:
     page_entries_info:
       one_page:
         display_entries:
-          zero: "No %{entry_name} found"
-          one: "Displaying <b>1</b> %{entry_name}"
-          other: "Displaying <b>all %{count}</b> %{entry_name}"
+          zero: ""
+          one: "<strong>1-1</strong>/1件中"
+          other: "<strong>1-%{count}</strong>/%{count}件中"
       more_pages:
-        display_entries: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b> in total"
+        display_entries: "<strong>%{first}-%{last}</strong>/%{total}件中"


### PR DESCRIPTION
# What
ページネーションの修正を行う。修正は以下の2点行う。
1.日本語化により生じたビューの崩れの修正
2.本物のメルカリを同じく、ページ番号の表示を5つに設定

# Why
より見易いページネーションにすることで、ユーザビリティを向上させる為。